### PR TITLE
#17 Users can create ride offers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7916,6 +7916,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
+    "nanoid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
+      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10308,6 +10313,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+    },
+    "shortid": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
+      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
+      "requires": {
+        "nanoid": "^2.0.0"
+      }
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "nodemon --watch src --exec babel-node ./src/index.js",
     "db:migrate": "sequelize db:migrate",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "jest --no-cache  --detectOpenHandles --runInBand --forceExit",
+    "test:watch": "jest --no-cache  --detectOpenHandles --runInBand --watch"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,8 @@
     "merge-graphql-schemas": "^1.5.8",
     "pg": "^7.7.1",
     "sequelize": "^4.42.0",
-    "sequelize-cli": "^5.4.0"
+    "sequelize-cli": "^5.4.0",
+    "shortid": "^2.2.14"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/database/migrations/20190215212748-create-ride-offer.js
+++ b/src/database/migrations/20190215212748-create-ride-offer.js
@@ -1,0 +1,52 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('RideOffers', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.STRING,
+      },
+      origin: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      destination: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      departureDate: {
+        allowNull: false,
+        type: Sequelize.DATEONLY,
+      },
+      departureTime: {
+        allowNull: false,
+        type: Sequelize.TIME,
+      },
+      userId: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id',
+          onDelete: 'CASCADE',
+        }
+      },
+      availableSeats: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('RideOffers');
+  }
+};

--- a/src/database/models/rideOffer.js
+++ b/src/database/models/rideOffer.js
@@ -1,0 +1,80 @@
+import { generate } from 'shortid';
+
+module.exports = (sequelize, DataTypes) => {
+  const RideOffer = sequelize.define('RideOffer', {
+    id: {
+      primaryKey: true,
+      type: DataTypes.STRING,
+    },
+    origin: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: {
+          args: true,
+          msg: 'origin must be provided'
+        },
+      },
+    },
+    destination: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: {
+          args: true,
+          msg: 'destination must be provided'
+        },
+      },
+    },
+    departureDate: {
+      allowNull: false,
+      type: DataTypes.DATEONLY,
+      validate: {
+        notEmpty: true,
+        isDate: {
+          msg: 'departure date must be of the format YYYY-MM-DD'
+        },
+      }
+    },
+    departureTime: {
+      allowNull: false,
+      type: DataTypes.TIME,
+      validate: {
+        isValidTime(time) {
+          const regex = /^\d{2}:(\d{2}:)?\d{2}$/;
+          if (!regex.test(time)) {
+            throw new Error('departure time must be of the format hh:mm:ss');
+          }
+        },
+        notEmpty: {
+          msg: 'departure time must be provided'
+        },
+      }
+    },
+    availableSeats: {
+      allowNull: false,
+      type: DataTypes.INTEGER,
+      validate: {
+        min: {
+          args: [1],
+          msg: 'There should be at least one available seat'
+        },
+        max: {
+          args: [10],
+          msg: 'Available seats should not be more than 10',
+        }
+      }
+    }
+  }, {});
+  RideOffer.associate = function(models) {
+    const { User } = models;
+    RideOffer.belongsTo(User, {
+      foreignKey: 'userId'
+    });
+  };
+
+  RideOffer.beforeCreate((ride) => {
+    ride.id = generate();
+  })
+  return RideOffer;
+};

--- a/src/resolvers/rideOffers/__tests__/rideOffers.tests.js
+++ b/src/resolvers/rideOffers/__tests__/rideOffers.tests.js
@@ -1,0 +1,85 @@
+import { runQuery, resetDB } from '../../../../test/helpers';
+import { User, RideOffer, sequelize } from '../../../database/models';
+
+describe('Ride Offers', () => {
+  let user;
+  beforeEach(async () => {
+    await resetDB();
+    user = await User.create({
+      username: 'testuser',
+      fullName: 'test user',
+      password: 'password',
+      email: 'testuser@mail.com'
+    });
+  });;
+
+  afterEach(async () => {
+    await resetDB();
+  });
+
+  it('should create a ride offer', async () => {
+    const result = await runQuery(`
+      mutation newRide($input: NewRideOffer!) {
+        rideOffer: createRideOffer(input: $input) {
+          id
+          origin
+          destination
+          departureDate
+          departureTime
+          availableSeats
+          offeredBy {
+            id
+            username
+            fullName
+            email
+            phone
+          }
+        }
+      }
+    `, {input: {
+          "origin": "Lagos",
+          "destination": "Nairobi",
+          "departureDate": "2019-02-19",
+          "departureTime": "19:56:00",
+          "availableSeats": "3"
+        }
+      }, user);
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.data.rideOffer).toBe('object');
+    expect(result.data.rideOffer).toHaveProperty('origin', 'Lagos');
+  });
+
+
+  it('should return error for unathenticated user', async () => {
+    const result = await runQuery(`
+      mutation newRide($input: NewRideOffer!) {
+        rideOffer: createRideOffer(input: $input) {
+          id
+          origin
+          destination
+          departureDate
+          departureTime
+          availableSeats
+          offeredBy {
+            id
+            username
+            fullName
+            email
+            phone
+          }
+        }
+      }
+    `, {input: {
+          "origin": "Lagos",
+          "destination": "Nairobi",
+          "departureDate": "2019-02-19",
+          "departureTime": "19:56:00",
+          "availableSeats": "3"
+        }
+      });
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors[0].message).toEqual('You are not authenticated');
+  });
+});

--- a/src/resolvers/rideOffers/rideOffers.resolvers.js
+++ b/src/resolvers/rideOffers/rideOffers.resolvers.js
@@ -1,0 +1,27 @@
+export default {
+  Mutation: {
+    createRideOffer: async function createRideOffer(parent, args,{ models, authedUser }) {
+      if(!authedUser || authedUser instanceof Error) {
+        const errorMessage = authedUser ? authedUser.message : 'You are not authenticated';
+        throw new Error(errorMessage);
+      }
+
+      const { input } = args;
+      /*
+        TODO: create custom handler for errors that can parse an error object
+        and properly format the errors before returning for graphql to handle
+        this would likely be used in a try catch
+      */
+      const rideOffer = await models.RideOffer.create({...input, userId: authedUser.id});
+
+      return rideOffer;
+    }
+  },
+
+  RideOffer: {
+    offeredBy: async function user(rideOffer, args, { models }) {
+      return await models.User.findByPk(rideOffer.userId);
+    }
+  }
+
+};

--- a/src/resolvers/user/__tests__/user.tests.js
+++ b/src/resolvers/user/__tests__/user.tests.js
@@ -1,17 +1,20 @@
-import { runQuery } from '../../../../test/helpers';
+import { runQuery, resetDB } from '../../../../test/helpers';
 import { User, sequelize } from '../../../database/models';
 
 describe('User', () => {
   let user;
   beforeEach(async () => {
-    const isTest = process.env.NODE_ENV === 'test';
-    await sequelize.sync({ force: isTest});
+    await resetDB();
     user = await User.create({
       username: 'testuser',
       fullName: 'test user',
       password: 'password',
       email: 'testuser@mail.com'
     });
+  });
+
+  afterEach(async () => {
+    await resetDB();
   });
 
   it('should getUsers', async () => {

--- a/src/schema/rideOffer.schema.graphql
+++ b/src/schema/rideOffer.schema.graphql
@@ -1,0 +1,21 @@
+type RideOffer {
+  id: ID!
+  origin: String!
+  destination: String!
+  departureDate: String!
+  departureTime: String!
+  availableSeats: Int!
+  offeredBy: User!
+}
+
+input NewRideOffer {
+  origin: String!
+  destination: String!
+  departureDate: String!
+  departureTime: String!
+  availableSeats: String!
+}
+
+type Mutation {
+  createRideOffer(input: NewRideOffer): RideOffer
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,7 +2,7 @@ import { graphql } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
 import { default as typeDefs } from '../src/schema';
 import resolvers from '../src/resolvers';
-import models from '../src/database/models';
+import models, { sequelize } from '../src/database/models';
 
 const schema = makeExecutableSchema({
   typeDefs,
@@ -11,4 +11,8 @@ const schema = makeExecutableSchema({
 
 export const runQuery = async (query, variables, authedUser) => {
   return graphql(schema, query, {}, { models, authedUser }, variables);
+}
+
+export const resetDB = async () => {
+  return await sequelize.sync({ force: true });
 }


### PR DESCRIPTION
#### What does this PR do?
Add ride offer creation functionality

#### Description of Task to be completed?
- include ride offer schema
- add mutation resolver for creating ride offer
- include test for ride offer resolver

#### How should this be manually tested?
- checkout this branch `git checkout ft-create-ride-#17`
- run `npm install`
- start dev server with `npm run dev`
- go to graphql playground and create a mutation as described below
```js
mutation newRide($input: NewRideOffer!) {
  rideOffer: createRideOffer(input: $input) {
    id
    origin
    destination
    departureDate
    departureTime
    availableSeats
    offeredBy {
      id
      username
      fullName
      email
      phone
    }
  }
}
```
- supply relevant query variables

#### Any background context you want to provide?
You need to be signed in with a valid jwt token

#### What are the relevant pivotal tracker stories?
[closes #17]

#### Screenshots (if appropriate)
n/a

#### Questions:
n/a